### PR TITLE
Configure WMF knobs

### DIFF
--- a/modules/wikiedu/files/application.yml
+++ b/modules/wikiedu/files/application.yml
@@ -1,0 +1,108 @@
+# Add configuration values here.
+#
+# Fulfill value requirements and save as application.yml
+#
+# Values required for WikiEduDashboard include:
+
+# The name of the dashboard
+  dashboard_title: Local Dashboard
+# The root url of the dashboard
+  dashboard_url: localhost:3000
+# description of the dashboard for the 'meta' html tag, which is used by search
+# engines
+  meta_description: dashboard for Wikipedia editing projects
+
+  contact_email: 'wikied@localhost.net'
+
+# a message to display to all users at the top of each page
+# sitenotice: "NOTICE: The system will go down for maintenance soon."
+
+  disable_onboarding: 'true'
+  disable_training: 'true'
+
+# Wikimedia OAuth consumer details. Register a consumer at:
+# https://www.mediawiki.org/wiki/Special:OAuthConsumerRegistration/propose
+# No one but the user who registers the consumer will be able to log in until
+# the consumer gets approved by Wikimedia Foundation staff.
+  wikipedia_token: YOURS
+  wikipedia_secret: YOURS
+
+# The language version of Wikipedia: <wiki_language>.wikipedia.org
+  wiki_language: en
+
+# The prefix for all course pages that get posted on behalf of users.
+# This should probably be in the Project (Wikipedia) namespace, and should be
+# a prefix that will only be used for this purpose.
+  course_prefix: 'Draft:WikiedDev'
+  course_talk_prefix: 'Draft_talk:WikiedDev'
+
+# This is the community discussion page where new courses should be announced.
+  course_announcement_page: 'Draft:WikiedDev'
+
+# Setting disable_wiki_output to 'true' means course pages will not be mirrored
+# to the wiki.
+  disable_wiki_output: 'true'
+
+# Setting to enable pulling data for legacy courses from the MediaWiki
+# EducationProgram extension (DEPRECATED).
+  enable_legacy_courses: 'false'
+
+# Set the default course type for newly created courses.  Use either
+# "ClassroomProgramCourse" or "BasicCourse".
+  default_course_type: BasicCourse
+
+# Setting enable_article_finder to 'true' enables the prototype article_finder
+# tool. Large queries can make the app unresponsive, so it's not ready for
+# production yet.
+  enable_article_finder: 'true'
+
+# Comma-separated list of OAuth client IDs used by the system for Wiki edits
+# FIXME: Where does this client ID come from?  metawiki seems to identify consumers by key.
+  oauth_ids: '252,212'
+
+# Page ID of the page that is used to indicate training completion. If a user
+# has edited this page, they will be counted as having completed training.
+# FIXME: Why an ID and not a title?
+  training_page_id: '36892501'
+
+# To set up error logging via Sentry, add a Sentry project url here:
+  sentry_dsn: 'http://somelongkey:anotherlongkey@sentry.localhost.net/1'
+  sentry_public_dsn: 'http://anotherlongkey@sentry.localhost.net/1'
+
+# One or more cohorts of classes, with each cohort defined by a wiki page of
+# course ids, one per line. For development, list at least 2 cohorts,
+# which are needed for integration tests.
+#
+# Cohort names become uppercase, and underscores become spaces.
+  cohorts: "fall_2014,spring_2015"
+
+## You can create wiki-based cohorts that pull data from the EP extension.
+## You should not do so.
+#  cohort_fall_2014: "Wikipedia:Education_program/Dashboard/Fall_2014_course_ids"
+  cohort_spring_2015: "Wikipedia:Education_program/Dashboard/course_ids"
+
+# The slug for the default cohort
+  default_cohort: "spring_2015"
+
+# How many days after a course ends should the dashboard continue updating
+# data for it?
+  update_length: "30"
+
+# What is the cutoff score for "article completeness" to flag articles/drafts
+# as potential DYK candidates?
+  dyk_wp10_limit: "30"
+
+# Uncomment cron_log_debug to use log level 'debug' for update logs. The default is 'info'.
+#  cron_log_debug: "true"
+
+# Uncomment no_views to disable view stats updates.
+# no_views: "true"
+
+# Logo filename, under the /images directory.
+  logo_file: "wiki-logo.png"
+
+# Favicon filename, under /images
+  favicon_file: "favicon.ico"
+
+# Development-mode favicon filename, under /images
+  favicon_dev_file: "favicon_dev.png"

--- a/modules/wikiedu/manifests/dashboard.pp
+++ b/modules/wikiedu/manifests/dashboard.pp
@@ -35,7 +35,7 @@ class wikiedu::dashboard(
     }
 
     file { "${dir}/config/application.yml":
-        source  => "${dir}/config/application.example.yml",
+        source  => 'puppet:///modules/wikiedu/application.yml',
         replace => false,
         require => Vcsrepo[$dir],
     }


### PR DESCRIPTION
This adds a configuration file, that includes Wikimedia tweaks to the
dashboard.  So far, it will disable training, onboarding, and sets the
default course type to our generic type, which disables the course
creator wizard.
